### PR TITLE
Midi-pedal-support

### DIFF
--- a/plugins/common/PedalBoard.hpp
+++ b/plugins/common/PedalBoard.hpp
@@ -11,12 +11,14 @@ public:
   {
     m_outputDCremoval.init(BiQuadFilter::FilterType::HighPass, 2.0, 1.0, 1.0, 48000);
     m_tuner.init();
+    m_loadedBoardId = -1;
   }
   // Initialize the pedal board. config should be a json::array() of pedals to construct
   // For an empty pedalboard, just pass in json::array()
   void init(json config)
   {
     markUnstable();
+    m_loadedBoardId = -1;
     std::this_thread::sleep_for(std::chrono::microseconds(2000));
     // Clear out any existing pedals
     for (auto &effect : m_chain)
@@ -120,6 +122,7 @@ public:
     json rval = {
         {"name", name},
         {"channel", channel},
+        {"boardId", m_loadedBoardId},
         {"effects", effects}};
     return rval;
   };
@@ -208,6 +211,9 @@ private:
 
     m_outputDCremoval.getBlock(inBuff, output, framesize);
   };
+
+public:
+  int m_loadedBoardId;
 
 private:
   bool m_stable;

--- a/plugins/rtjam-sound/src/JamEngine.cpp
+++ b/plugins/rtjam-sound/src/JamEngine.cpp
@@ -140,6 +140,7 @@ void JamEngine::getParams()
         cerr << "failed to parse json!" << endl;
       }
     }
+    break;
   case paramInsertPedal:
     if ((m_param.iValue >= 0 && m_param.iValue < 2) && (m_param.iValue2 >= 0))
     {
@@ -166,7 +167,9 @@ void JamEngine::getParams()
     {
       if (m_param.iValue >= 0 && m_param.iValue < 2)
       {
-        m_pedalBoards[m_param.iValue].init(json::parse(m_param.sValue)["config"]);
+        json boardInfo = json::parse(m_param.sValue);
+        m_pedalBoards[m_param.iValue].init(boardInfo["config"]);
+        m_pedalBoards[m_param.iValue].m_loadedBoardId = boardInfo["id"];
         syncConfigData();
       }
     }

--- a/plugins/rtjam-sound/src/main.cpp
+++ b/plugins/rtjam-sound/src/main.cpp
@@ -18,6 +18,23 @@ jack_port_t *midi_port;
 bool useMidi = false;
 jack_client_t *client = NULL;
 
+// Utility to shell out a command
+string execMyCommand(string cmd)
+{
+    array<char, 128> buffer;
+    string result;
+    unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"), pclose);
+    if (!pipe)
+    {
+        return "popen() failed!";
+    }
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr)
+    {
+        result += buffer.data();
+    }
+    return result;
+}
+
 static void signal_handler(int sig)
 {
     jack_client_close(client);
@@ -110,6 +127,10 @@ int main(int argc, char *argv[])
             sleep(1);
         }
     }
+
+    // If we got here, jack is running.  Let's try to start a2j midi bridge
+    execMyCommand("a2j_control start");
+
     if (status & JackNameNotUnique)
     {
         client_name = jack_get_client_name(client);


### PR DESCRIPTION
* restart a2j_control when rtjam-sound starts
* Store board ID  with pedal data so app can know what board is loaded on the device