### PR TITLE
New api to collect events over http

### DIFF
--- a/doc/piRoot/etc/nginx/sites-enabled/default
+++ b/doc/piRoot/etc/nginx/sites-enabled/default
@@ -14,11 +14,11 @@ server {
     client_max_body_size 1M;
     proxy_pass http://rtjam-nation.basscleftech.com;
     proxy_http_version 1.1;
-#    proxy_set_header Upgrade $http_upgrade;
-#    proxy_set_header Connection 'upgrade';
-#    proxy_set_header Host $host;
-#    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-#    proxy_cache_bypass $http_upgrade;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_cache_bypass $http_upgrade;
   }
 
   location /rtjambox {

--- a/plugins/rtjam-box/src/BoxAPI.hpp
+++ b/plugins/rtjam-box/src/BoxAPI.hpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <fstream>
 #include "EffectFactory.hpp"
+#include "MidiEvent.hpp"
 
 using namespace std;
 using json = nlohmann::json;
@@ -21,6 +22,7 @@ public:
   static string s_token;
   static ParamData s_paramData;
   static LevelData s_levelData;
+  static uint64_t s_jsonTimeStamp;
 
 private:
   RTJamLevels m_jamLevels;
@@ -35,6 +37,10 @@ private:
     else if (environment().requestUri.find("config") != string::npos)
     {
       getConfig();
+    }
+    else if (environment().requestUri.find("collect") != string::npos)
+    {
+      getCollect();
     }
     else
     {
@@ -81,6 +87,85 @@ private:
           {"peak1", m_jamLevels.peakLevels[(i * 2) + 1]},
       });
     }
+    out << result.dump(2);
+  }
+
+  void getCollect()
+  {
+    json result = {};
+    // Get shared memory data local
+    memcpy(&m_jamLevels, s_levelData.m_pJamLevels, sizeof(RTJamLevels));
+
+    // Build the level data
+    result["levels"] = {
+        {"jamUnitToken", s_token},
+        {"masterLevel", m_jamLevels.masterLevel},
+        {"peakMaster", m_jamLevels.peakMaster},
+        {"inputLeft", m_jamLevels.inputLeft},
+        {"inputRight", m_jamLevels.inputRight},
+        {"peakLeft", m_jamLevels.peakLeft},
+        {"peakRight", m_jamLevels.peakRight},
+        {"roomInputLeft", m_jamLevels.roomLevelLeft},
+        {"roomInputRight", m_jamLevels.roomLevelRight},
+        {"roomPeakLeft", m_jamLevels.roomPeakLeft},
+        {"roomPeakRight", m_jamLevels.roomPeakRight},
+        {"inputLeftFreq", m_jamLevels.inputLeftFreq},
+        {"inputRightFreq", m_jamLevels.inputRightFreq},
+        {"leftTunerOn", m_jamLevels.leftTunerOn},
+        {"rightTunerOn", m_jamLevels.rightTunerOn},
+        {"leftRoomMute", m_jamLevels.leftRoomMute},
+        {"rightRoomMute", m_jamLevels.rightRoomMute},
+        {"beat", m_jamLevels.beat},
+        {"connected", m_jamLevels.isConnected},
+        {"players", json::array()},
+    };
+    for (int i = 0; i < MAX_JAMMERS; i++)
+    {
+      result["levels"]["players"].push_back({
+          {"clientId", m_jamLevels.clientIds[i]},
+          {"depth", m_jamLevels.bufferDepths[i * 2] * 40},
+          {"level0", m_jamLevels.channelLevels[i * 2]},
+          {"level1", m_jamLevels.channelLevels[(i * 2) + 1]},
+          {"peak0", m_jamLevels.peakLevels[i * 2]},
+          {"peak1", m_jamLevels.peakLevels[(i * 2) + 1]},
+      });
+    }
+
+    // Now build the pedalTypes
+    result["pedalTypes"] = s_PedalTypes;
+
+    // Now update board config if it has changed
+    if (s_jsonTimeStamp != m_jamLevels.jsonTimeStamp)
+    {
+      try
+      {
+        s_jsonTimeStamp = m_jamLevels.jsonTimeStamp;
+        result["pedalInfo"] = json::parse(s_levelData.m_pJsonInfo);
+        // We need to forward the pedalboard json data
+      }
+      catch (json::exception &e)
+      {
+        cerr << "error parsing pedalboard" << endl;
+        cerr << e.what() << endl;
+      }
+      catch (...)
+      {
+        cerr << "error parsing pedalboard" << endl;
+      }
+    }
+
+    // Lastly collect any midi messages that may have come in
+    result["midiMessages"] = json::array();
+    while (s_levelData.m_pRingBuffer->readIdx != s_levelData.m_pRingBuffer->writeIdx)
+    {
+      // There is something in the ring buffer
+      unsigned char *pBuf = &s_levelData.m_pRingBuffer->ringBuffer[s_levelData.m_pRingBuffer->readIdx++ * 28];
+      // Construct a MidiEvent using the pBuf
+      MidiEvent event((const snd_seq_event_t *)pBuf);
+      result["midiMessages"].push_back(event.toJson().dump());
+      s_levelData.m_pRingBuffer->readIdx % 32;
+    }
+
     out << result.dump(2);
   }
 

--- a/plugins/rtjam-box/src/main.cpp
+++ b/plugins/rtjam-box/src/main.cpp
@@ -10,6 +10,7 @@ using namespace std;
 LevelData BoxAPI::s_levelData;
 string BoxAPI::s_token = "";
 ParamData BoxAPI::s_paramData;
+uint64_t BoxAPI::s_jsonTimeStamp = 1;
 
 UnitChatRobot robot;
 

--- a/plugins/rtjam-box/src/main.cpp
+++ b/plugins/rtjam-box/src/main.cpp
@@ -7,11 +7,15 @@
 
 using namespace std;
 
+// Static class data initialization from BoxAPI
 LevelData BoxAPI::s_levelData;
 string BoxAPI::s_token = "";
 ParamData BoxAPI::s_paramData;
 uint64_t BoxAPI::s_jsonTimeStamp = 1;
-
+bool BoxAPI::s_cmdOutputDirty = false;
+string BoxAPI::s_cmdOuput = "";
+bool BoxAPI::s_pedalTypesDirty = true;
+bool BoxAPI::s_audioHardwareDirty = false;
 UnitChatRobot robot;
 
 bool isRunning = true;


### PR DESCRIPTION
adds new endpoint /rtjamparam/collect that can be polled to pull events.  levels, pedals, cmds, audiohardware, and pedaltypes will be passed back in the json.  Works with <UnitPoll> in the web app.