### PR TITLE
Disconnect timer

### DIFF
--- a/plugins/common/JamNetStuff.cpp
+++ b/plugins/common/JamNetStuff.cpp
@@ -525,21 +525,4 @@ namespace JamNetStuff
             sizeof(struct sockaddr));
         return rval;
     }
-
-    std::string JamSocket::getMacAddress()
-    {
-        char mac[32];
-        struct ifreq ifr;
-        ifr.ifr_addr.sa_family = AF_INET;
-        strncpy(ifr.ifr_name, "eth0", IFNAMSIZ - 1);
-        ioctl(jamSocket, SIOCGIFHWADDR, &ifr);
-        sprintf(mac, "%.2x:%.2x:%.2x:%.2x:%.2x:%.2x\n",
-                (unsigned char)ifr.ifr_hwaddr.sa_data[0],
-                (unsigned char)ifr.ifr_hwaddr.sa_data[1],
-                (unsigned char)ifr.ifr_hwaddr.sa_data[2],
-                (unsigned char)ifr.ifr_hwaddr.sa_data[3],
-                (unsigned char)ifr.ifr_hwaddr.sa_data[4],
-                (unsigned char)ifr.ifr_hwaddr.sa_data[5]);
-        return mac;
-    }
 }

--- a/plugins/common/JamNetStuff.hpp
+++ b/plugins/common/JamNetStuff.hpp
@@ -290,7 +290,6 @@ namespace JamNetStuff
     int getTempo() { return m_tempo; };
     std::map<unsigned, float> getLatency() { return m_playerList.getLatency(); };
     void getClientIds(uint32_t *ids) { m_packet.getClientIds(ids); };
-    ::std::string getMacAddress();
 
   private:
     PlayerList m_playerList;

--- a/plugins/common/RTJamNationApi.cpp
+++ b/plugins/common/RTJamNationApi.cpp
@@ -16,7 +16,7 @@ json resultJson;
 RTJamNationApi::RTJamNationApi(string urlbase)
 {
   m_urlBase = urlbase;
-  checkLinkStatus();
+  checkLinkStatus("eth0");
 }
 
 bool RTJamNationApi::status()
@@ -171,7 +171,7 @@ bool RTJamNationApi::post(string url, json body)
     return -1;                \
   } while (0)
 
-bool RTJamNationApi::checkLinkStatus()
+bool RTJamNationApi::checkLinkStatus(string interface)
 {
   bool rval = false;
   int rv;
@@ -183,7 +183,7 @@ bool RTJamNationApi::checkLinkStatus()
     ERROR("Socket failed. Errno = %d\n", errno);
 
   struct ifreq if_req;
-  (void)strncpy(if_req.ifr_name, "eth0", sizeof(if_req.ifr_name));
+  (void)strncpy(if_req.ifr_name, interface.c_str(), sizeof(if_req.ifr_name));
 
   // get the interface up flags
   if (ioctl(socId, SIOCGIFFLAGS, &if_req) == -1)

--- a/plugins/common/RTJamNationApi.hpp
+++ b/plugins/common/RTJamNationApi.hpp
@@ -25,7 +25,7 @@ public:
   bool playerList(string roomToken);
   json m_resultBody;
   long m_httpResponseCode;
-  bool checkLinkStatus();
+  bool checkLinkStatus(string interface);
 
 private:
   bool put(string url, json body);

--- a/plugins/rtjam-box/src/main.cpp
+++ b/plugins/rtjam-box/src/main.cpp
@@ -57,6 +57,7 @@ int jamNationStuff()
     settings.saveVersionFile();
     settings.loadFromFile();
     string urlBase = settings.getOrSetValue("rtjam-nation", "rtjam-nation.basscleftech.com/api/1/");
+    string networkInterface = settings.getOrSetValue("networkInterface", "eth0");
     settings.setValue("gitCommit", GIT_HASH);
     int version = stoi(settings.getOrSetValue("rtjam-unit-version", "0"));
     settings.saveToFile();
@@ -66,7 +67,7 @@ int jamNationStuff()
     while (isRunning)
     {
         // printf("Light color: %d\n", lightData.m_pLightSettings->status);
-        if (api.checkLinkStatus())
+        if (api.checkLinkStatus(networkInterface))
         {
             if (loopCount % 10 == 0)
             {

--- a/plugins/rtjam-sound/src/JamEngine.cpp
+++ b/plugins/rtjam-sound/src/JamEngine.cpp
@@ -247,7 +247,8 @@ void JamEngine::run(const float **inputs, float **outputs, uint32_t frames)
     // It's been 60 minutes since we connected or we got a paramConnectionKeepAlive
     // Time to disconnect
     // TODO: Put this back in once I figure why it's not working correctly.
-    // disconnect();
+    cout << "Disconnect timeout: " << now - m_connectionTime << endl;
+    disconnect();
   }
 
   m_framecount += frames;

--- a/plugins/rtjam-sound/src/main.cpp
+++ b/plugins/rtjam-sound/src/main.cpp
@@ -115,9 +115,6 @@ int main(int argc, char *argv[])
         }
     }
 
-    // If we got here, jack is running.  Let's try to start a2j midi bridge
-    execMyCommand("a2j_control start");
-
     if (status & JackNameNotUnique)
     {
         client_name = jack_get_client_name(client);


### PR DESCRIPTION
When people just kill the web app and forget to disconnect their jam unit it will continue sending to the broadcast server indefinitely.  This fix will auto disconnect the audio stream after one hour of not getting a keepAlive message from the web app.

re-enable disconnect timer.
make network interface name a setting